### PR TITLE
Link that appeared when you typed 'aws timber' into Google was broken

### DIFF
--- a/timber-platforms/aws-cloudwatch/readme.md
+++ b/timber-platforms/aws-cloudwatch/readme.md
@@ -1,6 +1,7 @@
 ---
 title: AWS CloudWatch
 description: Enables log integration with most AWS services, such as Lambda, RDS, API Gateway, and more.
+url: aws-cloudwatch-logs
 items_append:
   - component: Divider
   - title: Github Repo


### PR DESCRIPTION
![screen shot 2018-07-24 at 12 21 26 pm](https://user-images.githubusercontent.com/19559943/43152345-4fe85c06-8f3c-11e8-81bb-ef038a501b38.png)

It would redirect to 'https://docs.timber.io/platforms/aws-cloudwatch-logs/' instead of 'https://docs.timber.io/platforms/aws-cloudwatch/'.

I just manually set the link.