### PR TITLE
Fix links to the Timber Agent documentation

### DIFF
--- a/timber-languages/ruby/configuration/logging-to-multiple-devices.md
+++ b/timber-languages/ruby/configuration/logging-to-multiple-devices.md
@@ -32,6 +32,6 @@ Just like the file example above, you could optionally wrap `STDOUT` in a `Logge
 
 ## Consider the Timber agent
 
-For the type-A minded, consider using the [Timber agent](/platforms/other/agent) to forward logs from your server/platform. Since you require an actual log file you can setup the Timber agent to tail that file and forward logs. This would alleviate your application from having to ship logs.
+For the type-A minded, consider using the [Timber agent](/platforms/other/timber-agent) to forward logs from your server/platform. Since you require an actual log file you can setup the Timber agent to tail that file and forward logs. This would alleviate your application from having to ship logs.
 
 Please note, this is _not_ necessary, and it does not result in any application performance improvements! The Timber HTTP log device is designed to be *highly* efficient using threads, batching, and msgpack. For more information on how to choose a log delivery method, see our [HTTP, STDOUT, or Files doc](/guides/http-stdout-or-log-files).

--- a/timber-platforms/aws-beanstalk/configuration/configuring-the-timber-agent.md
+++ b/timber-platforms/aws-beanstalk/configuration/configuring-the-timber-agent.md
@@ -1,11 +1,11 @@
 # Configuring the Timber Agent
 
-[The Timber agent](/platforms/other/agent) is what powers Elastic Beanstlak log delivery in the background. As a result, most confiration of Timber in the ElasticBeanstalk environment is done by [configuring the Timber agent](/platforms/other/agent/configuration-file).
+[The Timber agent](/platforms/other/timber-agent) is what powers Elastic Beanstlak log delivery in the background. As a result, most confiration of Timber in the ElasticBeanstalk environment is done by [configuring the Timber agent](/platforms/other/timber-agent/configuration-file).
 
 
 ## How to
 
-At the top of your Timber ebextension file you'll notice an entry for `/etc/timber.toml`. Simply modify the contents of this file based on the [available Timber agent configuration options](/platforms/other/agent/configuration-file):
+At the top of your Timber ebextension file you'll notice an entry for `/etc/timber.toml`. Simply modify the contents of this file based on the [available Timber agent configuration options](/platforms/other/timber-agent/configuration-file):
 
 ```toml
 ---

--- a/timber-platforms/linux/installation/amazon-linux.md
+++ b/timber-platforms/linux/installation/amazon-linux.md
@@ -5,7 +5,7 @@ related:
 - /platforms/linux/installation/amazon-linux/line-by-line-explanation
 - /platforms/linux/troubleshooting
 ---
-1. *Execute* this shell script on the desired [Amazon Linux](https://aws.amazon.com/amazon-linux-ami/) server to install the [Timber Agent](/platforms/other/agent)
+1. *Execute* this shell script on the desired [Amazon Linux](https://aws.amazon.com/amazon-linux-ami/) server to install the [Timber Agent](/platforms/other/timber-agent)
 
     ```sh
     curl -o /opt/timber-agent.tar.gz https://packages.timber.io/agent/0.6.x/linux-amd64/timber-agent-0.6.x-linux-amd64.tar.gz

--- a/timber-platforms/linux/installation/general-linux.md
+++ b/timber-platforms/linux/installation/general-linux.md
@@ -5,7 +5,7 @@ related:
 - /platforms/linux/installation/systemd-linux/line-by-line-explanation
 - /platforms/linux/troubleshooting
 ---
-1. We support all Linux-based systems through the [Timber Agent](/platforms/other/agent) which collects logs from files on your server.
+1. We support all Linux-based systems through the [Timber Agent](/platforms/other/timber-agent) which collects logs from files on your server.
 
     For the majority of modern distributions, you can use the following shell script to install the agent on your machine. It assumes your system uses `systemd`. (Don't worry if you don't know what that means!)
 

--- a/timber-platforms/linux/installation/readme.md
+++ b/timber-platforms/linux/installation/readme.md
@@ -1,6 +1,6 @@
 # Linux Installation
 
-We support Linux-based systems through our [cross-platform agent](/platforms/other/agent). For most Linux distributions, you can use our [General Linux](/platforms/linux/installation/systemd-linux) installation instructions.
+We support Linux-based systems through our [cross-platform agent](/platforms/other/timber-agent). For most Linux distributions, you can use our [General Linux](/platforms/linux/installation/systemd-linux) installation instructions.
 
 We have specific instructions for [Amazon Linux](/platforms/linux/installation/amazon-linux) since it requires some different scripts than other major distributions.
 

--- a/timber-platforms/linux/readme.md
+++ b/timber-platforms/linux/readme.md
@@ -3,4 +3,4 @@ description: Deliver log files of any type from platforms like EC2, DigitalOcean
 ---
 # Linux Platform
 
-With Timber's [Linux](https://www.linux.org/) integration you can seamlessly deliver log files of any type on Linux systems to your Timber account. This includes popular platforms like EC2, DigitalOcean, Google Cloud Platform, Microsoft Azure, and more. This allows you to maximize the utility of your Linux logs through Timber's modern interface and features. Delivery is achieved by using our [light weight highly efficient binary agent](/platforms/other/agent).
+With Timber's [Linux](https://www.linux.org/) integration you can seamlessly deliver log files of any type on Linux systems to your Timber account. This includes popular platforms like EC2, DigitalOcean, Google Cloud Platform, Microsoft Azure, and more. This allows you to maximize the utility of your Linux logs through Timber's modern interface and features. Delivery is achieved by using our [light weight highly efficient binary agent](/platforms/other/timber-agent).

--- a/timber-platforms/other/timber-agent/installation.md
+++ b/timber-platforms/other/timber-agent/installation.md
@@ -12,7 +12,7 @@
     * [NetBSD AMD64 latest](https://packages.timber.io/agent/0.x.x/netbsd-amd64/timber-agent-0.x.x-netbsd-amd64.tar.gz)
     * [OpenBSD AMD64 latest](https://packages.timber.io/agent/0.x.x/openbsd-amd64/timber-agent-0.x.x-openbsd-amd64.tar.gz)
 
-    All releases can be found [here](https://github.com/timberio/agent/releases). More special download links can be found [here](/platforms/other/agent/versioning).
+    All releases can be found [here](https://github.com/timberio/agent/releases). More special download links can be found [here](/platforms/other/timber-agent/versioning).
 
 2. Unpack the archive to a common location like `/opt`:
 


### PR DESCRIPTION
This fixes links to the Timber Agent documentation. Links were pointed at `/platforms/other/agent`, but the documentation redesign moved these links to `/platforms/other/timber-agent`.